### PR TITLE
Add BscScan buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,8 +116,8 @@
   <section id="poolStats">
     <div class="container">
       <h3 id="poolStatsTitle">Pool Statistics</h3>
-      <p><span id="currentPoolLabel"><img src="icons/bnb.svg" class="icon" alt="BNB"> Current BNB Pool:</span> <span id="poolAmount">-</span> BNB</p>
-      <p><span id="usd1PoolLabel"><img src="icons/usd1.svg" class="icon" alt="USD1"> Current USD1 Pool:</span> <span id="usd1PoolAmount">-</span> USD1</p>
+      <p><span id="currentPoolLabel"><img src="icons/bnb.svg" class="icon" alt="BNB"> Current BNB Pool:</span> <span id="poolAmount">-</span> BNB <button id="bnbScanBtn">BscScan</button></p>
+      <p><span id="usd1PoolLabel"><img src="icons/usd1.svg" class="icon" alt="USD1"> Current USD1 Pool:</span> <span id="usd1PoolAmount">-</span> USD1 <button id="usd1ScanBtn">BscScan</button></p>
     <div style="height: 20px;"></div>
       <p><a id="fullHistory" target="_blank">Full History</a></p>
     </div>

--- a/script.js
+++ b/script.js
@@ -67,6 +67,10 @@ function applyContractAddress() {
     fullHistory.href = `https://bscscan.com/address/${addr}#events`;
     fullHistory.target = '_blank';
   }
+  const bnbScanBtn = document.getElementById('bnbScanBtn');
+  if (bnbScanBtn) bnbScanBtn.onclick = () => window.open(`https://bscscan.com/address/${addr}`, '_blank');
+  const usd1ScanBtn = document.getElementById('usd1ScanBtn');
+  if (usd1ScanBtn) usd1ScanBtn.onclick = () => window.open(`https://bscscan.com/address/${addr}`, '_blank');
 }
 
 /* ===== Placeholder helpers ===== */
@@ -297,6 +301,12 @@ function updateLanguage() {
     fullHistory.href = `https://bscscan.com/address/${CONTRACT_ADDRESS}#events`;
     fullHistory.target = '_blank';
   }
+
+  const bnbScanBtn = document.getElementById('bnbScanBtn');
+  if (bnbScanBtn) bnbScanBtn.innerText = lang ? 'View on BscScan' : '在 BscScan 查看';
+
+  const usd1ScanBtn = document.getElementById('usd1ScanBtn');
+  if (usd1ScanBtn) usd1ScanBtn.innerText = lang ? 'View on BscScan' : '在 BscScan 查看';
 
   const contractAddrEl = document.getElementById('contractAddr');
   if (contractAddrEl) contractAddrEl.innerText = CONTRACT_ADDRESS;
@@ -543,7 +553,7 @@ function copyToClipboard(id) {
 }
 
 /* ===== Dark mode ===== */
-window.onload = async () => {
+if (typeof window !== 'undefined' && window) window.onload = async () => {
   document.body.classList.add('dark-mode');  // 預設啟用深色模式
   applyContractAddress();
   updateLanguage();
@@ -557,7 +567,7 @@ window.onload = async () => {
 };
 
 // 放在 script.js 的結尾
-window.addEventListener('DOMContentLoaded', (event) => {
+if (typeof window !== 'undefined' && window.addEventListener) window.addEventListener('DOMContentLoaded', (event) => {
   applyContractAddress();
   // 自動填充推薦人地址
   const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- show BscScan buttons beside the BNB and USD1 pool info
- wire new buttons to open the contract on BscScan
- update language handler for the new buttons
- guard DOM event listeners when window is unavailable

## Testing
- `npx jest` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684d1813d6dc832fb6f392fd3a2c28bc