### PR TITLE
Convert BscScan pool links to icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,8 +119,8 @@
   <section id="poolStats">
     <div class="container">
       <h3 id="poolStatsTitle">Pool Statistics</h3>
-      <p><span id="currentPoolLabel"><img src="icons/bnb.svg" class="icon" alt="BNB"> Current BNB Pool:</span> <span id="poolAmount">-</span> BNB <button id="bnbScanBtn">BscScan</button></p>
-      <p><span id="usd1PoolLabel"><img src="icons/usd1.svg" class="icon" alt="USD1"> Current USD1 Pool:</span> <span id="usd1PoolAmount">-</span> USD1 <button id="usd1ScanBtn">BscScan</button></p>
+      <p><span id="currentPoolLabel"><img src="icons/bnb.svg" class="icon" alt="BNB"> Current BNB Pool:</span> <span id="poolAmount">-</span> BNB <a id="bnbScanLink" href="#" target="_blank" rel="noopener noreferrer"><img src="bscscan.svg" alt="BscScan" class="bscscan-icon"></a></p>
+      <p><span id="usd1PoolLabel"><img src="icons/usd1.svg" class="icon" alt="USD1"> Current USD1 Pool:</span> <span id="usd1PoolAmount">-</span> USD1 <a id="usd1ScanLink" href="#" target="_blank" rel="noopener noreferrer"><img src="bscscan.svg" alt="BscScan" class="bscscan-icon"></a></p>
     <div style="height: 20px;"></div>
       <p><a id="fullHistory" target="_blank">Full History</a></p>
     </div>

--- a/script.js
+++ b/script.js
@@ -67,10 +67,10 @@ function applyContractAddress() {
     fullHistory.href = `https://bscscan.com/address/${addr}#events`;
     fullHistory.target = '_blank';
   }
-  const bnbScanBtn = document.getElementById('bnbScanBtn');
-  if (bnbScanBtn) bnbScanBtn.onclick = () => window.open(`https://bscscan.com/address/${addr}`, '_blank');
-  const usd1ScanBtn = document.getElementById('usd1ScanBtn');
-  if (usd1ScanBtn) usd1ScanBtn.onclick = () => window.open(`https://bscscan.com/address/${addr}`, '_blank');
+  const bnbScanLink = document.getElementById("bnbScanLink");
+  if (bnbScanLink) bnbScanLink.href = `https://bscscan.com/address/${addr}`;
+  const usd1ScanLink = document.getElementById("usd1ScanLink");
+  if (usd1ScanLink) usd1ScanLink.href = `https://bscscan.com/token/0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d?a=${addr}`;
 }
 
 /* ===== Placeholder helpers ===== */
@@ -302,11 +302,11 @@ function updateLanguage() {
     fullHistory.target = '_blank';
   }
 
-  const bnbScanBtn = document.getElementById('bnbScanBtn');
-  if (bnbScanBtn) bnbScanBtn.innerText = lang ? 'View on BscScan' : '在 BscScan 查看';
+  const bnbScanLink = document.getElementById("bnbScanLink");
+  if (bnbScanLink) bnbScanLink.href = `https://bscscan.com/address/${CONTRACT_ADDRESS}`;
 
-  const usd1ScanBtn = document.getElementById('usd1ScanBtn');
-  if (usd1ScanBtn) usd1ScanBtn.innerText = lang ? 'View on BscScan' : '在 BscScan 查看';
+  const usd1ScanLink = document.getElementById("usd1ScanLink");
+  if (usd1ScanLink) usd1ScanLink.href = `https://bscscan.com/token/0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d?a=${CONTRACT_ADDRESS}`;
 
   const contractAddrEl = document.getElementById('contractAddr');
   if (contractAddrEl) contractAddrEl.innerText = CONTRACT_ADDRESS;


### PR DESCRIPTION
## Summary
- replace BscScan buttons in Pool Statistics with icon links
- update script logic for new link IDs

## Testing
- `npx jest --runInBand` *(fails: jsdom environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1ba63544832facd2514de2d2fbb1