### PR TITLE
Add USD1 pool payout history link

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@
           <img src="bscscan.svg" alt="BscScan" class="bscscan-icon"></a></p>
       <div style="height: 20px;"></div>
       <p><a id="fullHistory" target="_blank">Full History</a></p>
+      <p><a id="usd1History" target="_blank">USD1 Pool History</a></p>
     </div>
   </section>
   

--- a/script.js
+++ b/script.js
@@ -84,6 +84,12 @@ function applyContractAddress() {
     fullHistory.href = `https://bscscan.com/address/${addr}#events`;
     fullHistory.target = "_blank";
   }
+  const usd1History = document.getElementById("usd1History");
+  if (usd1History) {
+    usd1History.href =
+      `https://bscscan.com/advanced-filter?tkn=0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d&txntype=2&fadd=${addr}&tadd=!${addr}`;
+    usd1History.target = "_blank";
+  }
   const bnbScanBtn = document.getElementById("bnbScanBtn");
   if (bnbScanBtn)
     bnbScanBtn.onclick = () =>
@@ -354,6 +360,15 @@ function updateLanguage() {
     fullHistory.innerText = lang ? "Full History" : "完整記錄";
     fullHistory.href = `https://bscscan.com/address/${CONTRACT_ADDRESS}#events`;
     fullHistory.target = "_blank";
+  }
+  const usd1History = document.getElementById("usd1History");
+  if (usd1History) {
+    usd1History.innerText = lang
+      ? "USD1 Pool History"
+      : "USD1 獎池發放紀錄";
+    usd1History.href =
+      `https://bscscan.com/advanced-filter?tkn=0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d&txntype=2&fadd=${CONTRACT_ADDRESS}&tadd=!${CONTRACT_ADDRESS}`;
+    usd1History.target = "_blank";
   }
 
   const bnbScanBtn = document.getElementById("bnbScanBtn");


### PR DESCRIPTION
## Summary
- add a dedicated USD1 pool history link in Pool Statistics
- support translations for the new link

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d2a363858832f96d8f4b04b9a7c05