### PR TITLE
Add token chart links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ BitLuck is a decentralized application (DApp) that enables users to participate 
 - **BSC Network**: This DApp is compatible with the BSC network only.
 - **Pool Statistics**: View the current BNB pool and the latest winner with a link to the full history on BscScan.
 - **BscScan Link**: Access the contract on BscScan using the new icon next to the contract address.
+- **Chart Links**: Quick access to price charts on **Dexscreener** and **Ave.ai**.
 
 
 ## How to Use

--- a/index.html
+++ b/index.html
@@ -55,6 +55,8 @@
         <a id="bscScanLink" href="#" target="_blank" rel="noopener noreferrer">
           <img src="bscscan.svg" alt="BscScan" class="bscscan-icon">
         </a>
+        <a id="dexscreenerLink" href="https://dexscreener.com/bsc/0x5771b751299c045a9617480bd7913c236b7c42e1" target="_blank" rel="noopener noreferrer">Dexscreener</a>
+        <a id="aveaiLink" href="https://ave.ai/token/0xac3789a484f4585bc7e30ec25b167a51ea2211d0-bsc?from=Home" target="_blank" rel="noopener noreferrer">Ave.ai</a>
         <button id="copyAddressBtn" onclick="copyToClipboard('contractAddr')">Copy Address</button>
         <button id="buyBtlLink" onclick="openPancakeSwap()" target="_blank">BUY $BTL</button>
       </p>

--- a/style.css
+++ b/style.css
@@ -389,3 +389,17 @@ footer p {
   vertical-align: middle;
   margin-left: 6px;
 }
+
+#dexscreenerLink,
+#aveaiLink {
+  margin-left: 6px;
+  color: #f0b90b;
+  font-weight: bold;
+  text-decoration: none;
+  transition: color 0.3s;
+}
+
+#dexscreenerLink:hover,
+#aveaiLink:hover {
+  color: #c8a500;
+}


### PR DESCRIPTION
## Summary
- add Dexscreener and Ave.ai links to the homepage
- style the new links
- document chart links in README

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_684d906656b8832fa101eb55fe6ccce6