### PR TITLE
Improve wallet connect RPC handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,7 +5,8 @@ const providerOptions =
         walletconnect: {
           package: window.WalletConnectProvider?.default,
           options: {
-            rpc: { 56: "https://bsc-dataseed1.binance.org:443" },
+            // Use a more reliable RPC endpoint
+            rpc: { 56: "https://rpc.ankr.com/bsc" },
           },
         },
       }
@@ -465,7 +466,10 @@ async function connectWallet() {
     updateContractInfo();
   } catch (e) {
     console.error(e);
-    toast("Connection failed");
+    const msg = e && e.message && e.message.includes("502")
+      ? "RPC error, please try again later."
+      : "Connection failed";
+    toast(msg);
   } finally {
     hideLoading("connectWalletBtn");
   }


### PR DESCRIPTION
## Summary
- use `https://rpc.ankr.com/bsc` as the wallet RPC endpoint
- show a more descriptive error if the RPC responds with 502

## Testing
- `npx jest --env=jsdom --runInBand` *(fails: __setUpdateUserInfo is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_684e9730d748832f9aa6ef0b681c631c