### PR TITLE
Add deposit safety checks

### DIFF
--- a/RoastPad.sol
+++ b/RoastPad.sol
@@ -7,12 +7,15 @@ contract RoastPad {
         uint256 lastAction;
         uint256 referralRewards;
         address referrer;
+        uint256 lastDepositTime;
     }
 
     mapping(address => User) public users;
     uint256 public totalDeposits;
     uint256 public constant DAILY_RATE = 8; // 8% daily
     uint256 public constant REFERRAL_RATE = 10; // 10% of referred deposit
+    uint256 public constant MAX_SINGLE_DEPOSIT = 100 ether;
+    uint256 public constant DEPOSIT_COOLDOWN = 1 days;
     address public owner;
     uint256 public platformFees;
 
@@ -35,7 +38,12 @@ contract RoastPad {
 
     function deposit(address _referrer) public payable {
         require(msg.value > 0, "Deposit must be > 0");
+        require(msg.value <= MAX_SINGLE_DEPOSIT, "Deposit exceeds limit");
         User storage user = users[msg.sender];
+        require(
+            block.timestamp - user.lastDepositTime >= DEPOSIT_COOLDOWN,
+            "Deposit cooldown active"
+        );
 
         if (user.deposit == 0 && _referrer != address(0) && _referrer != msg.sender) {
             user.referrer = _referrer;
@@ -45,6 +53,7 @@ contract RoastPad {
 
         user.deposit += msg.value;
         user.lastAction = block.timestamp;
+        user.lastDepositTime = block.timestamp;
         totalDeposits += msg.value;
 
         if (user.referrer != address(0)) {
@@ -61,6 +70,10 @@ contract RoastPad {
     function withdraw() external {
         _claimYield(msg.sender);
         User storage user = users[msg.sender];
+        require(
+            block.timestamp - user.lastDepositTime >= DEPOSIT_COOLDOWN,
+            "Cannot withdraw within 24h"
+        );
         uint256 amount = user.deposit;
         require(amount > 0, "Nothing to withdraw");
 


### PR DESCRIPTION
## Summary
- add deposit cooldown & lock
- enforce 100 ETH max deposit per transaction

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68511a732ef0832f8ae81e43c61fbd74