### PR TITLE
Add user info display

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,13 @@
     </div>
   </section>
 
+  <section id="userStats">
+    <div class="container">
+      <p><strong id="userDepositLabel">Deposit:</strong> <span id="userDeposit">-</span> BNB</p>
+      <p><strong id="userYieldLabel">Yield:</strong> <span id="userYield">-</span> BNB</p>
+    </div>
+  </section>
+
   <section id="hero">
     <div class="container">
       <img src="og-1200x630.png" alt="BitLuck" class="hero-img" />


### PR DESCRIPTION
## Summary
- display user's deposit and yield amounts on the home page
- fetch deposit and yield data from RoastPad contract
- update language strings for the new labels
- refresh info after deposit/withdraw/claim actions

## Testing
- `npm install`
- `npx --yes jest`

------
https://chatgpt.com/codex/tasks/task_e_6851403b12d4832f89c2f8f214fe23bb