### PR TITLE
Make referral link text copyable

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
       <button id="withdrawBnbBtn" onclick="withdrawBNB()">Withdraw</button>
       <button id="claimReferralBtn" onclick="claimReferralRewards()">Claim Referral Rewards</button>
       <p id="myReferralLink"></p>
-      <p id="referralContainer">Your Link: <span id="referralLink"></span>
+      <p id="referralContainer">Your Link: <span id="referralLink" onclick="copyToClipboard('referralLink')"></span>
         <button id="copyReferralBtn" onclick="copyToClipboard('referralLink')">Copy</button>
       </p>
     </div>

--- a/style.css
+++ b/style.css
@@ -380,6 +380,10 @@ footer p {
   cursor: pointer;
 }
 
+#referralLink {
+  cursor: pointer;
+}
+
 .bscscan-icon {
   width: 20px;
   height: 20px;


### PR DESCRIPTION
## Summary
- allow referral link text itself to copy URL on click
- show pointer cursor when hovering over referral link

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685145bce284832f9f88d6d5f312be28