### PR TITLE
Adjust BTL deposit input step

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,13 +78,13 @@
         <img src="bscscan.svg" alt="BscScan" class="bscscan-icon">
       </a>
     </p>
-    <input id="btlDepositAmount" type="number" step="0.01" min="0.01" placeholder="Amount (BTL)">
+    <input id="btlDepositAmount" type="number" step="1000000000" min="1000000000" placeholder="Amount (BTL)">
     <input id="btlReferrer" type="text" placeholder="Referrer (optional)">
     <button id="depositBtlBtn" onclick="depositBTLRoast()">Deposit BTL</button>
     <button id="withdrawBtlBtn" onclick="withdrawBTLRoast()">Withdraw All</button>
     <button id="claimBtlReferralBtn" onclick="claimBtlReferralRewards()">Claim Referral Rewards</button>
 
-    <p id="BtlDepositRules" class="rules">Daily yield is 8%. Deposits and withdrawals have a 15-seconds cooldown. Each action settles your rewards. Deposit at least 100000000 $BTL (0.01%) daily to settle without withdrawing all.</p>
+    <p id="BtlDepositRules" class="rules">Daily yield is 8%. Deposits and withdrawals have a 15-seconds cooldown. Each action settles your rewards. Deposit at least 1000000000 $BTL (0.01%) daily to settle without withdrawing all.</p>
     
     <p><strong id="btlUserDepositLabel">Total Deposit:</strong> <span id="btlUserDeposit">-</span> BTL</p>
     <p><strong id="btlUserYieldLabel">Total Yield:</strong> <span id="btlUserYield">-</span> BTL</p>

--- a/script.js
+++ b/script.js
@@ -260,8 +260,8 @@ function updateLanguage() {
   const BtlDepositRules = document.getElementById("BtlDepositRules");
   if (BtlDepositRules)
     BtlDepositRules.innerText = lang
-      ? "Daily yield is 8%. Deposits and withdrawals have a 15-seconds cooldown. Each action settles your rewards. Deposit at least 100000000 $BTL (0.01%) daily to settle without withdrawing all."
-      : "每日收益率為 8%。存款和提款有 15 秒的冷卻時間。每次操作會結算您的獎勳。每日至少存入 100000000 $BTL（0.01%）以便結算，而無需全部提領。";
+      ? "Daily yield is 8%. Deposits and withdrawals have a 15-seconds cooldown. Each action settles your rewards. Deposit at least 1000000000 $BTL (0.01%) daily to settle without withdrawing all."
+      : "每日收益率為 8%。存款和提款有 15 秒的冷卻時間。每次操作會結算您的獎勳。每日至少存入 1000000000 $BTL（0.01%）以便結算，而無需全部提領。";
   
   const depositRules = document.getElementById("depositRules");
   if (depositRules)


### PR DESCRIPTION
## Summary
- set BTL deposit input step and minimum to `1000000000`
- update BTL deposit rule text in both English and Chinese

## Testing
- `npm test` *(fails: Missing script)*
- `npx jest` *(interactive package installation prompt)*


------
https://chatgpt.com/codex/tasks/task_e_68516d1d13e0832fa4ccea710bfcd45c