### PR TITLE
Add auto-refresh feature for user info

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "dotenv": "^16.5.0",
     "ethers": "^6.14.4",
+    "jest": "^30.0.0",
     "mongodb": "^6.17.0"
   }
 }


### PR DESCRIPTION
## Summary
- refresh user info automatically every minute
- expose refresh utilities in script
- include Jest dependency for testing

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68516f4261fc832fabbe0e04df910bcc