### PR TITLE
Add token approval before BTL deposits

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Visit [http://localhost:8000/index.html](http://localhost:8000/index.html) in yo
 ## Wallet Setup
 - Click **Connect Wallet** in the DApp and select MetaMask or Rabby.
 - Deposit BTL tokens to start earning rewards.
+- On your first deposit the DApp will request approval to spend your BTL tokens.
 
 ## Deposit & Withdrawal Rules
 - The minimum amount you can deposit is **0.01 BNB**.

--- a/script.js
+++ b/script.js
@@ -78,6 +78,17 @@ const ERC20_ABI = [
     stateMutability: "view",
     type: "function",
   },
+  {
+    constant: false,
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "value", type: "uint256" },
+    ],
+    name: "approve",
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
 ];
 
 // Backwards compatibility wrapper for older method names
@@ -684,11 +695,16 @@ async function depositBTLRoast() {
   if (btn && btn.dataset.loading === "true") return;
   showLoading(btnId);
   try {
+    const weiAmount = web3.utils.toWei(amount, "ether");
+    const token = new web3.eth.Contract(ERC20_ABI, CONTRACT_ADDRESS);
+    await token.methods
+      .approve(BTL_ROASTPAD_ADDRESS, weiAmount)
+      .send({ from: userAccount });
     const refAddr = web3.utils.isAddress(ref)
       ? ref
       : "0x0000000000000000000000000000000000000000";
     await btlRoastPadContract.methods
-      .deposit(refAddr, web3.utils.toWei(amount, "ether"))
+      .deposit(refAddr, weiAmount)
       .send({ from: userAccount });
     if (typeof updateBtlUserInfo === "function") updateBtlUserInfo();
     toast(currentLanguage === "en" ? "Deposit successful!" : "存款成功!");


### PR DESCRIPTION
## Summary
- extend `ERC20_ABI` with `approve`
- approve BTL tokens before calling deposit on the roast pad contract
- document new approval step in README

## Testing
- `npm install`
- `node -e "console.log('ok')"`


------
https://chatgpt.com/codex/tasks/task_e_6851710d1d40832fae2062cf86e8ed1c