### PR TITLE
Add gas limit to withdrawal and referral functions

### DIFF
--- a/script.js
+++ b/script.js
@@ -698,7 +698,7 @@ async function claimReferralRewards() {
   try {
     await roastPadContract.methods
       .claimReferralRewards()
-      .send({ from: userAccount });
+      .send({ from: userAccount, gas: 300000 });
     if (typeof updateUserInfo === "function") updateUserInfo();
     toast(currentLanguage === "en" ? "Rewards claimed!" : "獎勵已領取!");
   } catch (e) {
@@ -756,7 +756,9 @@ async function withdrawBTLRoast() {
   if (btn && btn.dataset.loading === "true") return;
   showLoading(btnId);
   try {
-    await btlRoastPadContract.methods.withdraw().send({ from: userAccount });
+    await btlRoastPadContract.methods
+      .withdraw()
+      .send({ from: userAccount, gas: 300000 });
     if (typeof updateBtlUserInfo === "function") updateBtlUserInfo();
     toast(currentLanguage === "en" ? "Withdraw all successful!" : "提取全部成功!");
   } catch (e) {


### PR DESCRIPTION
## Summary
- set explicit gas limit for withdrawing and claiming referral rewards

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68519da75490832fad55f9c955b359f0