### PR TITLE
Specify gas limits for user transactions

### DIFF
--- a/script.js
+++ b/script.js
@@ -741,7 +741,7 @@ async function depositBNB() {
       : "0x0000000000000000000000000000000000000000";
     await roastPadContract.methods
       .deposit(referrer || "0x0000000000000000000000000000000000000000")
-      .send({ from: userAccount, value: web3.utils.toWei(amount, "ether") });
+      .send({ from: userAccount, value: web3.utils.toWei(amount, "ether"), gas: 300000 });
     if (typeof updateUserInfo === "function") updateUserInfo();
     toast(currentLanguage === "en" ? "Deposit successful!" : "存款成功!");
   } catch (e) {
@@ -766,7 +766,7 @@ async function withdrawBNB() {
   if (btn && btn.dataset.loading === "true") return;
   showLoading(btnId);
   try {
-    await roastPadContract.methods.withdraw().send({ from: userAccount });
+    await roastPadContract.methods.withdraw().send({ from: userAccount, gas: 300000 });
     if (typeof updateUserInfo === "function") updateUserInfo();
     toast(currentLanguage === "en" ? "Withdraw all successful!" : "提取全部成功!");
   } catch (e) {
@@ -830,7 +830,7 @@ async function depositBTLRoast() {
       : "0x0000000000000000000000000000000000000000";
     await btlRoastPadContract.methods
       .deposit(refAddr, weiAmount)
-      .send({ from: userAccount });
+      .send({ from: userAccount, gas: 300000 });
     if (typeof updateBtlUserInfo === "function") updateBtlUserInfo();
     toast(currentLanguage === "en" ? "Deposit successful!" : "存款成功!");
   } catch (e) {
@@ -876,7 +876,7 @@ async function claimBtlReferralRewards() {
   try {
     await btlRoastPadContract.methods
       .claimReferralRewards()
-      .send({ from: userAccount });
+      .send({ from: userAccount, gas: 300000 });
     if (typeof updateBtlUserInfo === "function") updateBtlUserInfo();
     toast(currentLanguage === "en" ? "Rewards claimed!" : "獎勵已領取!");
   } catch (e) {
@@ -979,7 +979,7 @@ async function depositBTL() {
     const referrer = refEl ? refEl.value.trim() : "";
     await depositContract.methods
       .depositBTL(weiAmount, referrer)
-      .send({ from: userAccount });
+      .send({ from: userAccount, gas: 300000 });
     if (typeof updateUserInfo === "function") updateUserInfo();
     toast(currentLanguage === "en" ? "Deposit successful" : "存款成功");
   } catch (e) {


### PR DESCRIPTION
## Summary
- ensure BNB and BTL transactions specify a gas value

## Testing
- `npx --yes jest`

------
https://chatgpt.com/codex/tasks/task_e_6851a178fb4c832faeb8faeea25e9511