### PR TITLE
Stop auto-calling user info after wallet connect

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -36,7 +36,7 @@ describe('depositBTL', () => {
         }))
       }
     };
-    global.web3 = { utils: { toWei: jest.fn() } };
+    global.web3 = { utils: { toWei: jest.fn(), isAddress: jest.fn(() => true) } };
     __setContract(global.depositContract);
     __setWeb3(global.web3);
     global.userAccount = '0xabc';

--- a/script.js
+++ b/script.js
@@ -524,8 +524,8 @@ if (netId !== 56) {
     updateBtlUserInfo = () => getBtlUserInfo(userAccount);
     toast(
       currentLanguage === "en"
-        ? 'Wallet connected. Click "Refresh Pool Info" to update.'
-        : '錢包已連接，請手動點「刷新礦池資訊」來更新狀態'
+        ? "Wallet connected. Please manually refresh your pool info."
+        : "錢包已連接，請手動刷新礦池資訊"
     );
 
     provider.on("accountsChanged", (acc) => {


### PR DESCRIPTION
## Summary
- tweak toast shown after connecting a wallet
- ensure tests stub `isAddress`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851a39f40b0832f9992b0b5ebe11029