### PR TITLE
Add button click cooldown

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -36,7 +36,7 @@ describe('depositBTL', () => {
         }))
       }
     };
-    global.web3 = { utils: { toWei: jest.fn() } };
+    global.web3 = { utils: { toWei: jest.fn(), isAddress: jest.fn(() => true) } };
     __setContract(global.depositContract);
     __setWeb3(global.web3);
     global.userAccount = '0xabc';


### PR DESCRIPTION
## Summary
- add global cooldown state and activation helper
- prevent double-clicks by checking `cooldownActive` across button handlers
- provide `isAddress` stub for tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851a3a560f4832fb1044dda411005ae