### PR TITLE
Add pool refresh button

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
       <button id="connectWalletBtn" onclick="connectWallet()">Connect Wallet</button>
       <span id="networkInfo">Not connected</span>
       <p id="userAccount"></p>
+      <button id="refreshInfoBtn" onclick="refreshInfo()">刷新礦池資訊</button>
     </div>
   </section>
   <!-- ===== Main Info ===== -->

--- a/script.js
+++ b/script.js
@@ -284,6 +284,8 @@ function updateLanguage() {
     claimBtlReferralBtn.innerText = lang
       ? "Claim Referral Rewards"
       : "領取推薦獎勵";
+  const refreshInfoBtn = document.getElementById("refreshInfoBtn");
+  if (refreshInfoBtn) refreshInfoBtn.innerText = lang ? "Refresh Pools" : "刷新礦池資訊";
   const depositAmountInput = document.getElementById("depositAmount");
   if (depositAmountInput)
     depositAmountInput.placeholder = lang
@@ -950,6 +952,26 @@ async function getBtlUserInfo(addr) {
     );
   }
 }
+
+async function refreshInfo() {
+  const btnId = "refreshInfoBtn";
+  const btn = document.getElementById(btnId);
+  if (btn && btn.dataset.loading === "true") return;
+  showLoading(btnId);
+  try {
+    if (typeof updateUserInfo === "function") await updateUserInfo();
+    if (typeof updateBtlUserInfo === "function") await updateBtlUserInfo();
+  } catch (e) {
+    console.error("Failed to refresh info", e);
+    toast(
+      currentLanguage === "en"
+        ? `Failed to refresh: ${e.message}`
+        : `刷新失敗: ${e.message}`
+    );
+  } finally {
+    hideLoading(btnId);
+  }
+}
 /* ===== PancakeSwap Link ===== */
 function openPancakeSwap() {
   const url = `https://pancakeswap.finance/swap?outputCurrency=${CONTRACT_ADDRESS}&chain=bsc`;
@@ -1121,6 +1143,7 @@ if (typeof module !== 'undefined') {
     withdraw: withdrawBNB,
     claimReferralRewards,
     claimBtlReferralRewards,
+    refreshInfo,
     getUserInfo,
     getBtlUserInfo,
     __setContract,


### PR DESCRIPTION
## Summary
- add "刷新礦池資訊" button in wallet section
- implement `refreshInfo` to call both pool update functions with loading and error toast
- localize button text based on language setting
- export new function for testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851a56b1bdc832fb40770025f6eabff