### PR TITLE
Refactor contract loading

### DIFF
--- a/script.js
+++ b/script.js
@@ -478,6 +478,13 @@ function updateLanguage() {
   updateMyReferralLink();
 }
 
+async function initContracts() {
+  if (!web3) return;
+  contract = new web3.eth.Contract(ABI, CONTRACT_ADDRESS);
+  roastPadContract = new web3.eth.Contract(ROASTPAD_ABI, ROASTPAD_ADDRESS);
+  btlRoastPadContract = new web3.eth.Contract(BTL_ROASTPAD_ABI, BTL_ROASTPAD_ADDRESS);
+}
+
 /* ===== Connect wallet ===== */
 async function connectWallet() {
   if (userAccount) {
@@ -515,10 +522,8 @@ if (netId !== 56) {
     return;
   }
 }
-    contract = new web3.eth.Contract(ABI, CONTRACT_ADDRESS);
-    roastPadContract = new web3.eth.Contract(ROASTPAD_ABI, ROASTPAD_ADDRESS);
-    btlRoastPadContract = new web3.eth.Contract(BTL_ROASTPAD_ABI, BTL_ROASTPAD_ADDRESS);
     userAccount = (await web3.eth.getAccounts())[0];
+    await initContracts();
     document.getElementById("userAccount").innerText = userAccount;
     updateReferralLink();
     updateMyReferralLink();


### PR DESCRIPTION
## Summary
- add `initContracts` helper and move all contract instantiation there
- call `initContracts` after fetching accounts in `tryConnect`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851a7c5b0fc832f81d8382ca9bc4871